### PR TITLE
The "Save changes" button should be disabled when no changes have bee…

### DIFF
--- a/static/templates/dialog_widget.hbs
+++ b/static/templates/dialog_widget.hbs
@@ -16,12 +16,40 @@
             </main>
             <footer class="modal__footer">
                 {{#unless single_footer_button}}
+                
+                
                 <button class="modal__btn dialog_cancel_button" aria-label="{{t 'Close this dialog window' }}" data-micromodal-close>{{t "Cancel" }}</button>
                 {{/unless}}
-                <button class="modal__btn dialog_submit_button"{{#if single_footer_button}} aria-label="{{t 'Close this dialog window' }}" data-micromodal-close{{/if}}>
+                
+                
+                
+                <button class="modal__btn dialog_submit_button"{{#if single_footer_button}} aria-label="{{t 'Close this dialog window' }}" data-micromodal-close{{/if}} id="btnSubmit" type="button" value="Submit" disabled="disabled"   >
+                   
+<script type="text/javascript">
+    function EnableDisable(txtPassportNumber) {
+        //Reference the Button.
+        var btnSubmit = document.getElementById("btnSubmit");
+ 
+        //Verify the TextBox value.
+        if (txtPassportNumber.value.trim() != "") {
+            //Enable the TextBox when TextBox has value.
+            btnSubmit.disabled = false;
+        } else {
+            //Disable the TextBox when TextBox is empty.
+            btnSubmit.disabled = true;
+        }
+    };
+</script>
+
+                   
+                   
                     <span>{{{ html_submit_button }}}</span>
                     <div class="modal__spinner"></div>
+                
+                
                 </button>
+                
+                
             </footer>
         </div>
     </div>


### PR DESCRIPTION
Disable "Save changes" button when no changes have been made.


Fixes part 2nd of #20831 


<!-- What's this PR for?  (Just a link to an issue is fine.) -->

**Testing plan:** <!-- How have you tested? -->

**GIFs or screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->

<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->








![1649237640591](https://user-images.githubusercontent.com/76876709/161945200-a848d45f-77cd-4599-8fbb-07e09e207968.jpg)<br>




![1649238152817 (1)](https://user-images.githubusercontent.com/76876709/161947250-8168eef8-f8f6-4963-90c8-67ee00b61c0f.jpg)








https://user-images.githubusercontent.com/76876709/161946064-d9f5b654-f0ae-4f5f-8f8a-05bd73b608f6.mp4










