### PR TITLE
fix: Long "Person" type profile field spills out of input box.

### DIFF
--- a/static/styles/input_pill.css
+++ b/static/styles/input_pill.css
@@ -36,10 +36,14 @@
             border-radius: 4px 0 0 4px;
         }
 
-        .pill-value {
+         .pill-value {
             margin: 0 5px;
+            white-space: nowrap;
+            width: 50px;
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
-
+        
         .exit {
             opacity: 0.5;
             font-size: 1.3em;


### PR DESCRIPTION
Abbreviating the name with "..." when it's too long to fit at max width.

Fixes: [#21807](https://github.com/zulip/zulip/issues/21807)

<!-- If the PR makes UI changes, always include one or more still screenshots to demonstrate your changes. If it seems helpful, add a screen capture of the new functionality as well.

Tooling tips: https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
-->

**Screenshots and screen captures:**

![zulipfix new issue](https://user-images.githubusercontent.com/76876709/163673532-b60c1607-6301-41d6-8186-858807d3a1db.gif)